### PR TITLE
adding the missing dependency for event-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "template-lint": "0.2.x",
     "aurelia-template-lint": "0.3.x",
+    "event-stream": "^3.3.2",
     "gulp": "3.x",
     "gulp-util": "3.x"
   }


### PR DESCRIPTION
Hi, if I didn't misunderstood everything, I think that the event-stream package dependency is missing. Adding it to the package.json let me use this package tha I simply love: thank's a lot for it!
